### PR TITLE
Shuffleboard Fixed

### DIFF
--- a/src/main/java/frc/robot/utils/shuffleboard/SmartShuffleboardTab.java
+++ b/src/main/java/frc/robot/utils/shuffleboard/SmartShuffleboardTab.java
@@ -48,7 +48,7 @@ public class SmartShuffleboardTab {
       GenericEntry ntEntry = widget.getEntry();
       ntEntry.setValue(value);
     } else {
-      widget = tab.add(fieldName, value);
+      widget = tab.add(fieldName, value).withWidget(BuiltInWidgets.kNumberSlider);
       widgetMap.put(fieldName, widget);
     }
     return widget;
@@ -126,7 +126,7 @@ public class SmartShuffleboardTab {
       }
 
       // adding the command to the tab
-      layout.add(fieldName, cmd);
+      layout.add(fieldName, cmd).withWidget(BuiltInWidgets.kCommand);
       commandSet.add(fieldName);
     }
   }


### PR DESCRIPTION
fixed our implementation of Shuffleboard (SmartShuffleboardTab). Set widget for .put() is "kNumberSlider" and may need to be adjusted using a new parameter 