### PR TITLE
fixed cancel all

### DIFF
--- a/src/main/java/frc/robot/commands/climber/StopClimber.java
+++ b/src/main/java/frc/robot/commands/climber/StopClimber.java
@@ -1,0 +1,20 @@
+package frc.robot.commands.climber;
+
+import frc.robot.subsystems.climber.ClimberSubsystem;
+import frc.robot.utils.logging.commands.LoggableCommand;
+
+public class StopClimber extends LoggableCommand {
+    private ClimberSubsystem climber;
+    public StopClimber(ClimberSubsystem climber) {
+        this.climber = climber;
+        addRequirements(climber);
+    }
+    @Override
+    public void initialize() {
+        climber.stopClimber();
+    }
+    @Override
+    public boolean isFinished() {
+        return true;
+    }
+}

--- a/src/main/java/frc/robot/commands/sequences/CancelAll.java
+++ b/src/main/java/frc/robot/commands/sequences/CancelAll.java
@@ -5,19 +5,24 @@
 package frc.robot.commands.sequences;
 
 import frc.robot.commands.ResetAll;
+import frc.robot.commands.climber.StopClimber;
 import frc.robot.subsystems.algaebyebyeroller.AlgaeByeByeRollerSubsystem;
 import frc.robot.subsystems.algaebyebyetilt.AlgaeByeByeTiltSubsystem;
+import frc.robot.subsystems.climber.ClimberSubsystem;
 import frc.robot.subsystems.elevator.ElevatorSubsystem;
+import frc.robot.subsystems.swervev3.SwerveDrivetrain;
 import frc.robot.utils.logging.commands.LoggableSequentialCommandGroup;
 
 /** Add your docs here. */
 public class CancelAll extends LoggableSequentialCommandGroup {
 
   public CancelAll(
-      AlgaeByeByeTiltSubsystem algaeByeByeTiltSubsystem,
-      AlgaeByeByeRollerSubsystem algaebyebyeroller,
-      ElevatorSubsystem elevatorSubsystem) {
+          AlgaeByeByeTiltSubsystem algaeByeByeTiltSubsystem,
+          AlgaeByeByeRollerSubsystem algaebyebyeroller,
+          ElevatorSubsystem elevatorSubsystem,
+          ClimberSubsystem climberSubsystem) {
     super(
+        new StopClimber(climberSubsystem),
         new ByeByeAllDone(algaeByeByeTiltSubsystem, algaebyebyeroller, elevatorSubsystem),
         //        new ResetAll(elevatorSubsystem, hihiExtenderSubsystem));
         new ResetAll(elevatorSubsystem));


### PR DESCRIPTION
No need to add extra auto align stuff because the ResetAll cancels all command, meaning the drive command will be called next, stopping the drivetrain. Climber just stops and this command is called first for safety reasons